### PR TITLE
Added security trait for behat tests + Neos 2.3 compatibility

### DIFF
--- a/Classes/Service/SampleImageService.php
+++ b/Classes/Service/SampleImageService.php
@@ -14,43 +14,47 @@ use TYPO3\Media\Domain\Model\Image;
 /**
  * @Flow\Scope("singleton")
  */
-class SampleImageService {
+class SampleImageService
+{
 
-	/**
-	 * @Flow\Inject
-	 * @var \TYPO3\Flow\Resource\ResourceManager
-	 */
-	protected $resourceManager;
+    /**
+     * @Flow\Inject
+     * @var \TYPO3\Flow\Resource\ResourceManager
+     */
+    protected $resourceManager;
 
-	/**
-	 * Inject PersistenceManagerInterface
-	 *
-	 * @Flow\Inject
-	 * @var \TYPO3\Flow\Persistence\PersistenceManagerInterface
-	 */
-	protected $persistenceManager;
+    /**
+     * Inject PersistenceManagerInterface
+     *
+     * @Flow\Inject
+     * @var \TYPO3\Flow\Persistence\PersistenceManagerInterface
+     */
+    protected $persistenceManager;
 
-	/**
-	 * @Flow\Inject
-	 * @var \TYPO3\Media\Domain\Repository\ImageRepository
-	 */
-	protected $imageRepository;
+    /**
+     * @Flow\Inject
+     * @var \TYPO3\Media\Domain\Repository\ImageRepository
+     */
+    protected $imageRepository;
 
-	/**
-	 * @param string $name image name (from Resources/Images)
-	 *
-	 * @return \TYPO3\Media\Domain\Model\ImageInterface
-	 */
-	public function getSampleImage($name) {
-		$query = $this->imageRepository->createQuery();
-		$result = $query->matching($query->equals('resource.filename', $name))->execute();
-		$image = null;
-		if (!($result && ($image = $result->getFirst()))) {
-			$image = new Image($this->resourceManager->importResource(sprintf('resource://CRON.Behat/Resources/Images/%s', $name)));
-			$this->imageRepository->add($image);
-			$this->persistenceManager->persistAll();
-		}
-		return $image;
-	}
+    /**
+     * @param string $name image name (from Resources/Images)
+     *
+     * @return \TYPO3\Media\Domain\Model\ImageInterface
+     */
+    public function getSampleImage($name)
+    {
+        $query = $this->imageRepository->createQuery();
+        $result = $query->matching($query->equals('resource.filename', $name))->execute();
+        $image = null;
+        if (!($result && ($image = $result->getFirst()))) {
+            $image = new Image($this->resourceManager->importResource(sprintf('resource://CRON.Behat/Resources/Images/%s',
+                $name)));
+            $this->imageRepository->add($image);
+            $this->persistenceManager->persistAll();
+        }
+
+        return $image;
+    }
 
 }

--- a/Tests/Behat/FeatureContextBase.php
+++ b/Tests/Behat/FeatureContextBase.php
@@ -16,8 +16,12 @@ use PHPUnit_Framework_Assert as Assert;
 require_once(__DIR__ . '/FlowContext.php');
 require_once(__DIR__ . '/NeosTrait.php');
 require_once(__DIR__ . '/../../../../Framework/TYPO3.Flow/Tests/Behavior/Features/Bootstrap/IsolatedBehatStepsTrait.php');
-require_once(__DIR__ . '/../../../../Neos/TYPO3.TYPO3CR/Tests/Behavior/Features/Bootstrap/NodeOperationsTrait.php');
 
+if (file_exists(__DIR__ . '/../../../../Application/TYPO3.TYPO3CR/Tests/Behavior/Features/Bootstrap/NodeOperationsTrait.php')) {
+	require_once(__DIR__ . '/../../../../Application/TYPO3.TYPO3CR/Tests/Behavior/Features/Bootstrap/NodeOperationsTrait.php');	
+} else {
+	require_once(__DIR__ . '/../../../../Neos/TYPO3.TYPO3CR/Tests/Behavior/Features/Bootstrap/NodeOperationsTrait.php');
+}
 /**
  * Class FeatureContextBase
  *

--- a/Tests/Behat/FeatureContextBase.php
+++ b/Tests/Behat/FeatureContextBase.php
@@ -19,10 +19,11 @@ require_once(__DIR__ . '/../../../../Framework/TYPO3.Flow/Tests/Behavior/Feature
 require_once(__DIR__ . '/../../../../Framework/TYPO3.Flow/Tests/Behavior/Features/Bootstrap/SecurityOperationsTrait.php');
 
 if (file_exists(__DIR__ . '/../../../../Application/TYPO3.TYPO3CR/Tests/Behavior/Features/Bootstrap/NodeOperationsTrait.php')) {
-	require_once(__DIR__ . '/../../../../Application/TYPO3.TYPO3CR/Tests/Behavior/Features/Bootstrap/NodeOperationsTrait.php');	
+    require_once(__DIR__ . '/../../../../Application/TYPO3.TYPO3CR/Tests/Behavior/Features/Bootstrap/NodeOperationsTrait.php');
 } else {
-	require_once(__DIR__ . '/../../../../Neos/TYPO3.TYPO3CR/Tests/Behavior/Features/Bootstrap/NodeOperationsTrait.php');
+    require_once(__DIR__ . '/../../../../Neos/TYPO3.TYPO3CR/Tests/Behavior/Features/Bootstrap/NodeOperationsTrait.php');
 }
+
 /**
  * Class FeatureContextBase
  *
@@ -31,262 +32,286 @@ if (file_exists(__DIR__ . '/../../../../Application/TYPO3.TYPO3CR/Tests/Behavior
  * This class implements some basic NEOS Backend steps and should be extended by the specific FeatureContext
  *
  */
-class FeatureContextBase extends \Behat\MinkExtension\Context\MinkContext {
+class FeatureContextBase extends \Behat\MinkExtension\Context\MinkContext
+{
 
-	use \TYPO3\TYPO3CR\Tests\Behavior\Features\Bootstrap\NodeOperationsTrait;
-	use \TYPO3\Flow\Tests\Behavior\Features\Bootstrap\IsolatedBehatStepsTrait;
-	use \TYPO3\Flow\Tests\Behavior\Features\Bootstrap\SecurityOperationsTrait;	
-	use NeosTrait;
+    use \TYPO3\TYPO3CR\Tests\Behavior\Features\Bootstrap\NodeOperationsTrait;
+    use \TYPO3\Flow\Tests\Behavior\Features\Bootstrap\IsolatedBehatStepsTrait;
+    use \TYPO3\Flow\Tests\Behavior\Features\Bootstrap\SecurityOperationsTrait;
+    use NeosTrait;
 
-	/**
-	 * @var string
-	 */
-	protected $behatTestHelperObjectName = \TYPO3\Neos\Tests\Functional\Command\BehatTestHelper::class;
+    /**
+     * @var string
+     */
+    protected $behatTestHelperObjectName = \TYPO3\Neos\Tests\Functional\Command\BehatTestHelper::class;
 
-	/**
-	 * @var \TYPO3\Flow\Object\ObjectManagerInterface
-	 */
-	protected $objectManager;
+    /**
+     * @var \TYPO3\Flow\Object\ObjectManagerInterface
+     */
+    protected $objectManager;
 
-	/**
-	 * @return \TYPO3\Flow\Object\ObjectManagerInterface
-	 */
-	protected function getObjectManager() {
-		return $this->objectManager;
-	}
+    /**
+     * @return \TYPO3\Flow\Object\ObjectManagerInterface
+     */
+    protected function getObjectManager()
+    {
+        return $this->objectManager;
+    }
 
-	/**
-	 * Initializes the context
-	 *
-	 * @param array $parameters Context parameters (configured through behat.yml)
-	 */
-	public function __construct(array $parameters) {
-		$this->useContext('flow', new FlowContext($parameters));
-		$this->objectManager = $this->getSubcontext('flow')->getObjectManager();
-		$this->setupSecurity();
-	}
+    /**
+     * Initializes the context
+     *
+     * @param array $parameters Context parameters (configured through behat.yml)
+     */
+    public function __construct(array $parameters)
+    {
+        $this->useContext('flow', new FlowContext($parameters));
+        $this->objectManager = $this->getSubcontext('flow')->getObjectManager();
+        $this->setupSecurity();
+    }
 
-	/**
-	 * Reset the content dimensions configuration
-	 * Note: this is very important, the value being set to 'default' => 'mul_ZZ' for Behat scenarios in
-	 * NodeOperationsTrait.php.
-	 *
-	 * @return void
-	 * @throws \Exception
-	 */
-	public function resetContentDimensions() {
-		if ($this->isolated === true) {
-			$this->callStepInSubProcess(__METHOD__);
-		} else {
-			$contentDimensionRepository = $this->getObjectManager()->get(\TYPO3\TYPO3CR\Domain\Repository\ContentDimensionRepository::class);
-			/** @var \TYPO3\TYPO3CR\Domain\Repository\ContentDimensionRepository $contentDimensionRepository */
+    /**
+     * Reset the content dimensions configuration
+     * Note: this is very important, the value being set to 'default' => 'mul_ZZ' for Behat scenarios in
+     * NodeOperationsTrait.php.
+     *
+     * @return void
+     * @throws \Exception
+     */
+    public function resetContentDimensions()
+    {
+        if ($this->isolated === true) {
+            $this->callStepInSubProcess(__METHOD__);
+        } else {
+            $contentDimensionRepository = $this->getObjectManager()->get(\TYPO3\TYPO3CR\Domain\Repository\ContentDimensionRepository::class);
+            /** @var \TYPO3\TYPO3CR\Domain\Repository\ContentDimensionRepository $contentDimensionRepository */
 
-			// Set the content dimensions to a fixed value for Behat scenarios
-			$contentDimensionRepository->setDimensionsConfiguration([]);
-		}
-	}
+            // Set the content dimensions to a fixed value for Behat scenarios
+            $contentDimensionRepository->setDimensionsConfiguration([]);
+        }
+    }
 
-	/**
-	 * @Given /^I imported the site "([^"]*)"$/
-	 */
-	public function iImportedTheSite($packageKey) {
-		// run the nodeindex:build to create the Elasticsearch index, if missing
-		$this->iRunNodeindex();
+    /**
+     * @Given /^I imported the site "([^"]*)"$/
+     */
+    public function iImportedTheSite($packageKey)
+    {
+        // run the nodeindex:build to create the Elasticsearch index, if missing
+        $this->iRunNodeindex();
 
-		/** @var \TYPO3\Neos\Domain\Service\SiteImportService $siteImportService */
-		$siteImportService = $this->objectManager->get(\TYPO3\Neos\Domain\Service\SiteImportService::class);
-		$siteImportService->importFromPackage($packageKey);
+        /** @var \TYPO3\Neos\Domain\Service\SiteImportService $siteImportService */
+        $siteImportService = $this->objectManager->get(\TYPO3\Neos\Domain\Service\SiteImportService::class);
+        $siteImportService->importFromPackage($packageKey);
 
-		$this->getSubcontext('flow')->persistAll();
-		$this->resetNodeInstances();
-	}
+        $this->getSubcontext('flow')->persistAll();
+        $this->resetNodeInstances();
+    }
 
-	/**
-	 * @Given /^I run nodeindex:build$/
-	 */
-	public function iRunNodeindex() {
-		/** @var \TYPO3\Neos\Domain\Service\SiteImportService $siteImportService */
-		/** @var \Flowpack\ElasticSearch\ContentRepositoryAdaptor\Command\NodeIndexCommandController $nodeIndexCommandController */
-		$nodeIndexCommandController = $this->objectManager->get(\Flowpack\ElasticSearch\ContentRepositoryAdaptor\Command\NodeIndexCommandController::class);
-		$nodeIndexCommandController->buildCommand();
-		$nodeIndexCommandController->cleanupCommand();
-	}
+    /**
+     * @Given /^I run nodeindex:build$/
+     */
+    public function iRunNodeindex()
+    {
+        /** @var \TYPO3\Neos\Domain\Service\SiteImportService $siteImportService */
+        /** @var \Flowpack\ElasticSearch\ContentRepositoryAdaptor\Command\NodeIndexCommandController $nodeIndexCommandController */
+        $nodeIndexCommandController = $this->objectManager->get(\Flowpack\ElasticSearch\ContentRepositoryAdaptor\Command\NodeIndexCommandController::class);
+        $nodeIndexCommandController->buildCommand();
+        $nodeIndexCommandController->cleanupCommand();
+    }
 
-	/**
-	 * Clear the code cache.
-	 *
-	 * @BeforeScenario @clearcodecache
-	 */
-	public function clearCodeCache() {
-		$directories = array_merge(
-			glob(FLOW_PATH_DATA . 'Temporary/Development/SubContextBehat/Cache')
-		);
-		if (is_array($directories)) {
-			foreach ($directories as $directory) {
-				\TYPO3\Flow\Utility\Files::removeDirectoryRecursively($directory);
-			}
-		}
-	}
+    /**
+     * Clear the code cache.
+     *
+     * @BeforeScenario @clearcodecache
+     */
+    public function clearCodeCache()
+    {
+        $directories = array_merge(
+            glob(FLOW_PATH_DATA . 'Temporary/Development/SubContextBehat/Cache')
+        );
+        if (is_array($directories)) {
+            foreach ($directories as $directory) {
+                \TYPO3\Flow\Utility\Files::removeDirectoryRecursively($directory);
+            }
+        }
+    }
 
-	/**
-	 * Clear the content cache. Since this could be needed for multiple Flow contexts, we have to do it on the
-	 * filesystem for now. Using a different cache backend than the FileBackend will not be possible with this approach.
-	 *
-	 * @BeforeScenario @fixtures
-	 */
-	public function clearContentCache() {
-		$directories = array_merge(
-			glob(FLOW_PATH_DATA . 'Temporary/*/Cache/Data/TYPO3_TypoScript_Content'),
-			glob(FLOW_PATH_DATA . 'Temporary/*/*/Cache/Data/TYPO3_TypoScript_Content')
-		);
-		if (is_array($directories)) {
-			foreach ($directories as $directory) {
-				\TYPO3\Flow\Utility\Files::removeDirectoryRecursively($directory);
-			}
-		}
-	}
+    /**
+     * Clear the content cache. Since this could be needed for multiple Flow contexts, we have to do it on the
+     * filesystem for now. Using a different cache backend than the FileBackend will not be possible with this approach.
+     *
+     * @BeforeScenario @fixtures
+     */
+    public function clearContentCache()
+    {
+        $directories = array_merge(
+            glob(FLOW_PATH_DATA . 'Temporary/*/Cache/Data/TYPO3_TypoScript_Content'),
+            glob(FLOW_PATH_DATA . 'Temporary/*/*/Cache/Data/TYPO3_TypoScript_Content')
+        );
+        if (is_array($directories)) {
+            foreach ($directories as $directory) {
+                \TYPO3\Flow\Utility\Files::removeDirectoryRecursively($directory);
+            }
+        }
+    }
 
-	/**
-	 * @Given /^I am authenticated with "([^"]*)" and "([^"]*)" for the backend$/
-	 */
-	public function iAmAuthenticatedWithAndForTheBackend($username, $password) {
-		$this->visit('/neos/login');
-		$this->fillField('Username', $username);
-		$this->fillField('Password', $password);
-		$this->pressButton('Login');
-	}
+    /**
+     * @Given /^I am authenticated with "([^"]*)" and "([^"]*)" for the backend$/
+     */
+    public function iAmAuthenticatedWithAndForTheBackend($username, $password)
+    {
+        $this->visit('/neos/login');
+        $this->fillField('Username', $username);
+        $this->fillField('Password', $password);
+        $this->pressButton('Login');
+    }
 
-	/**
-	 * @Given /^the following users exist:$/
-	 */
-	public function theFollowingUsersExist(TableNode $table) {
-		$rows = $table->getHash();
-		/** @var \TYPO3\Neos\Domain\Service\UserService $userService */
-		$userService = $this->objectManager->get(\TYPO3\Neos\Domain\Service\UserService::class);
-		/** @var \TYPO3\Party\Domain\Repository\PartyRepository $partyRepository */
-		$partyRepository = $this->objectManager->get(\TYPO3\Party\Domain\Repository\PartyRepository::class);
-		/** @var \TYPO3\Flow\Security\AccountRepository $accountRepository */
-		$accountRepository = $this->objectManager->get(\TYPO3\Flow\Security\AccountRepository::class);
-		foreach ($rows as $row) {
-			$roleIdentifiers = array_map(function ($role) {
-				return 'TYPO3.Neos:' . $role;
-			}, Arrays::trimExplode(',', $row['roles']));
-			if ($user = $userService->getUser($row['username'])) {
-				$userService->deleteUser($user);
-				$this->getSubcontext('flow')->persistAll();
-			}
-			$userService->createUser($row['username'], $row['password'], $row['firstname'], $row['lastname'], $roleIdentifiers);
-		}
-		$this->getSubcontext('flow')->persistAll();
-	}
+    /**
+     * @Given /^the following users exist:$/
+     */
+    public function theFollowingUsersExist(TableNode $table)
+    {
+        $rows = $table->getHash();
+        /** @var \TYPO3\Neos\Domain\Service\UserService $userService */
+        $userService = $this->objectManager->get(\TYPO3\Neos\Domain\Service\UserService::class);
+        /** @var \TYPO3\Party\Domain\Repository\PartyRepository $partyRepository */
+        $partyRepository = $this->objectManager->get(\TYPO3\Party\Domain\Repository\PartyRepository::class);
+        /** @var \TYPO3\Flow\Security\AccountRepository $accountRepository */
+        $accountRepository = $this->objectManager->get(\TYPO3\Flow\Security\AccountRepository::class);
+        foreach ($rows as $row) {
+            $roleIdentifiers = array_map(function ($role) {
+                return 'TYPO3.Neos:' . $role;
+            }, Arrays::trimExplode(',', $row['roles']));
+            if ($user = $userService->getUser($row['username'])) {
+                $userService->deleteUser($user);
+                $this->getSubcontext('flow')->persistAll();
+            }
+            $userService->createUser($row['username'], $row['password'], $row['firstname'], $row['lastname'],
+                $roleIdentifiers);
+        }
+        $this->getSubcontext('flow')->persistAll();
+    }
 
-	/**
-	 * @param callable $callback
-	 * @param integer $timeout Timeout in milliseconds
-	 * @param string $message
-	 */
-	public function spinWait($callback, $timeout, $message = '') {
-		$waited = 0;
-		while ($callback() !== true) {
-			if ($waited > $timeout) {
-				Assert::fail($message);
+    /**
+     * @param callable $callback
+     * @param integer $timeout Timeout in milliseconds
+     * @param string $message
+     */
+    public function spinWait($callback, $timeout, $message = '')
+    {
+        $waited = 0;
+        while ($callback() !== true) {
+            if ($waited > $timeout) {
+                Assert::fail($message);
 
-				return;
-			}
-			usleep(50000);
-			$waited += 50;
-		}
-	}
+                return;
+            }
+            usleep(50000);
+            $waited += 50;
+        }
+    }
 
-	/**
-	 * @When /^I select the first headline content element$/
-	 */
-	public function iSelectTheFirstHeadlineContentElement() {
-		$element = $this->assertSession()->elementExists('css', 'h1.neos-inline-editable');
-		$element->click();
+    /**
+     * @When /^I select the first headline content element$/
+     */
+    public function iSelectTheFirstHeadlineContentElement()
+    {
+        $element = $this->assertSession()->elementExists('css', 'h1.neos-inline-editable');
+        $element->click();
 
-		$this->selectedContentElement = $element;
-	}
+        $this->selectedContentElement = $element;
+    }
 
 
-	private $selectedContentElement = null;
+    private $selectedContentElement = null;
 
-	/**
-	 * @Given /^I set the content to "([^"]*)"$/
-	 */
-	public function iSetTheContentTo($content) {
-		$editable = $this->assertSession()->elementExists('css', '.neos-inline-editable', $this->selectedContentElement);
+    /**
+     * @Given /^I set the content to "([^"]*)"$/
+     */
+    public function iSetTheContentTo($content)
+    {
+        $editable = $this->assertSession()->elementExists('css', '.neos-inline-editable',
+            $this->selectedContentElement);
 
-		$this->getSession()->wait(2000);
-		$this->spinWait(function () use ($editable) {
-			return $editable->hasAttribute('contenteditable');
-		}, 12000, 'editable has contenteditable attribute set');
+        $this->getSession()->wait(2000);
+        $this->spinWait(function () use ($editable) {
+            return $editable->hasAttribute('contenteditable');
+        }, 12000, 'editable has contenteditable attribute set');
 
-		$editable->setValue($content);
-	}
+        $editable->setValue($content);
+    }
 
-	/**
-	 * @Given /^I click the Publish button$/
-	 */
-	public function iClickThePublishButton() {
-		$this->getSession()->wait(3000);
-		$button = $this->assertSession()->elementExists('css', 'button.neos-publish-button');
-		$button->click();
-		$this->getSession()->wait(3000);
-	}
+    /**
+     * @Given /^I click the Publish button$/
+     */
+    public function iClickThePublishButton()
+    {
+        $this->getSession()->wait(3000);
+        $button = $this->assertSession()->elementExists('css', 'button.neos-publish-button');
+        $button->click();
+        $this->getSession()->wait(3000);
+    }
 
-	/**
-	 * @Given /^I wait for the changes to be saved$/
-	 */
-	public function iWaitForTheChangesToBeSaved() {
-		$this->getSession()->wait(30000, '$(".neos-publish-menu-active").length > 0');
-		$this->assertSession()->elementExists('css', '.neos-publish-menu-active');
-		// after the publish button being active, wait some time for the AJAX request to finish
-		$this->getSession()->wait(4000);
-	}
+    /**
+     * @Given /^I wait for the changes to be saved$/
+     */
+    public function iWaitForTheChangesToBeSaved()
+    {
+        $this->getSession()->wait(30000, '$(".neos-publish-menu-active").length > 0');
+        $this->assertSession()->elementExists('css', '.neos-publish-menu-active');
+        // after the publish button being active, wait some time for the AJAX request to finish
+        $this->getSession()->wait(4000);
+    }
 
-	/**
-	 * @When /^I select the NEOS Inspector$/
-	 */
-	public function iSelectTheNeosInspector() {
-		// wait 30 seconds for the NEOS BE to appear
-		$this->getSession()->wait(30000, '$("#neos-inspector").length > 0');
-		$this->selectedContentElement = $this->assertSession()->elementExists('css', '.neos-inspector-form');
-	}
+    /**
+     * @When /^I select the NEOS Inspector$/
+     */
+    public function iSelectTheNeosInspector()
+    {
+        // wait 30 seconds for the NEOS BE to appear
+        $this->getSession()->wait(30000, '$("#neos-inspector").length > 0');
+        $this->selectedContentElement = $this->assertSession()->elementExists('css', '.neos-inspector-form');
+    }
 
-	/**
-	 * @Given /^I open the Date Picker$/
-	 */
-	public function iOpenTheDatePicker() {
-		// wait for the date picker to be fully loaded
-		$this->getSession()->wait(10000, '$("#neos-inspector input.neos-editor-datetimepicker-hrvalue").length > 0');
-		$this->assertSession()->elementExists('css', '.neos-editor-datetimepicker-hrvalue', $this->selectedContentElement)->click();
-		// wait to fully expand
-		$this->getSession()->wait(10000, '$("#neos-inspector div.neos-editor-datetimepicker").is(":visible")');
-	}
+    /**
+     * @Given /^I open the Date Picker$/
+     */
+    public function iOpenTheDatePicker()
+    {
+        // wait for the date picker to be fully loaded
+        $this->getSession()->wait(10000, '$("#neos-inspector input.neos-editor-datetimepicker-hrvalue").length > 0');
+        $this->assertSession()->elementExists('css', '.neos-editor-datetimepicker-hrvalue',
+            $this->selectedContentElement)->click();
+        // wait to fully expand
+        $this->getSession()->wait(10000, '$("#neos-inspector div.neos-editor-datetimepicker").is(":visible")');
+    }
 
-	/**
-	 * @Given /^click on Today in the Date Picker$/
-	 */
-	public function clickOnTodayInTheDatePicker() {
-		$this->getSession()->wait(10000, '$(".neos-datetimepicker-days .neos-today").is(":visible")');
-		$this->assertSession()->elementExists('css', '.neos-datetimepicker-days .neos-today', $this->selectedContentElement)->click();
-	}
+    /**
+     * @Given /^click on Today in the Date Picker$/
+     */
+    public function clickOnTodayInTheDatePicker()
+    {
+        $this->getSession()->wait(10000, '$(".neos-datetimepicker-days .neos-today").is(":visible")');
+        $this->assertSession()->elementExists('css', '.neos-datetimepicker-days .neos-today',
+            $this->selectedContentElement)->click();
+    }
 
-	/**
-	 * @Given /^click Apply$/
-	 */
-	public function clickApply() {
-		$this->assertSession()->elementExists('css', '.neos-inspector-apply')->click();
+    /**
+     * @Given /^click Apply$/
+     */
+    public function clickApply()
+    {
+        $this->assertSession()->elementExists('css', '.neos-inspector-apply')->click();
 //        $this->getSession()->wait(10000);
-	}
+    }
 
-	/**
-	 * @Then /^I should see "([^"]*)" in the (\d+)\. element having css class "(?P<element>[^"]*)"$/
-	 */
-	public function iShouldSeeInTheElementHavingCssClass($text, $nth, $cssClass) {
-		$element = sprintf("//*[@class='%s'][%d]", $cssClass, $nth);
-		$this->assertSession()->elementTextContains('xpath', $element, $this->fixStepArgument($text));
-	}
+    /**
+     * @Then /^I should see "([^"]*)" in the (\d+)\. element having css class "(?P<element>[^"]*)"$/
+     */
+    public function iShouldSeeInTheElementHavingCssClass($text, $nth, $cssClass)
+    {
+        $element = sprintf("//*[@class='%s'][%d]", $cssClass, $nth);
+        $this->assertSession()->elementTextContains('xpath', $element, $this->fixStepArgument($text));
+    }
 
 }

--- a/Tests/Behat/FeatureContextBase.php
+++ b/Tests/Behat/FeatureContextBase.php
@@ -16,6 +16,7 @@ use PHPUnit_Framework_Assert as Assert;
 require_once(__DIR__ . '/FlowContext.php');
 require_once(__DIR__ . '/NeosTrait.php');
 require_once(__DIR__ . '/../../../../Framework/TYPO3.Flow/Tests/Behavior/Features/Bootstrap/IsolatedBehatStepsTrait.php');
+require_once(__DIR__ . '/../../../../Framework/TYPO3.Flow/Tests/Behavior/Features/Bootstrap/SecurityOperationsTrait.php');
 
 if (file_exists(__DIR__ . '/../../../../Application/TYPO3.TYPO3CR/Tests/Behavior/Features/Bootstrap/NodeOperationsTrait.php')) {
 	require_once(__DIR__ . '/../../../../Application/TYPO3.TYPO3CR/Tests/Behavior/Features/Bootstrap/NodeOperationsTrait.php');	
@@ -34,6 +35,7 @@ class FeatureContextBase extends \Behat\MinkExtension\Context\MinkContext {
 
 	use \TYPO3\TYPO3CR\Tests\Behavior\Features\Bootstrap\NodeOperationsTrait;
 	use \TYPO3\Flow\Tests\Behavior\Features\Bootstrap\IsolatedBehatStepsTrait;
+	use \TYPO3\Flow\Tests\Behavior\Features\Bootstrap\SecurityOperationsTrait;	
 	use NeosTrait;
 
 	/**
@@ -61,6 +63,7 @@ class FeatureContextBase extends \Behat\MinkExtension\Context\MinkContext {
 	public function __construct(array $parameters) {
 		$this->useContext('flow', new FlowContext($parameters));
 		$this->objectManager = $this->getSubcontext('flow')->getObjectManager();
+		$this->setupSecurity();
 	}
 
 	/**

--- a/Tests/Behat/FlowContext.php
+++ b/Tests/Behat/FlowContext.php
@@ -10,17 +10,19 @@ require_once(__DIR__ . '/../../../../Application/Flowpack.Behat/Tests/Behat/Flow
  * Date: 12.03.16
  * Time: 09:22
  */
-class FlowContext extends \Flowpack\Behat\Tests\Behat\FlowContext {
+class FlowContext extends \Flowpack\Behat\Tests\Behat\FlowContext
+{
 
-	/**
-	 * @AfterSuite
-	 */
-	public static function shutdownFlow() {
-		if (self::$bootstrap !== NULL) {
-			// WORKAROUND: don't call shutdown() to workaround Doctrine\ORM\ORMInvalidArgumentException
-			// A detached entity was found during removed..
-			//self::$bootstrap->shutdown('Runtime');
-		}
-	}
+    /**
+     * @AfterSuite
+     */
+    public static function shutdownFlow()
+    {
+        if (self::$bootstrap !== null) {
+            // WORKAROUND: don't call shutdown() to workaround Doctrine\ORM\ORMInvalidArgumentException
+            // A detached entity was found during removed..
+            //self::$bootstrap->shutdown('Runtime');
+        }
+    }
 
 }

--- a/Tests/Behat/NeosTrait.php
+++ b/Tests/Behat/NeosTrait.php
@@ -12,210 +12,227 @@ use Behat\Gherkin\Node\TableNode;
 use CRON\Behat\Service\SampleImageService;
 use PHPUnit_Framework_Assert as Assert;
 
-trait NeosTrait {
+trait NeosTrait
+{
 
-	protected $context = null;
+    protected $context = null;
 
-	/**
-	 * @return \TYPO3\Neos\Domain\Service\ContentContext
-	 */
-	protected function getContext() {
+    /**
+     * @return \TYPO3\Neos\Domain\Service\ContentContext
+     */
+    protected function getContext()
+    {
 
-		if ($this->context === null) {
-			/** @var \TYPO3\Neos\Domain\Repository\SiteRepository $siteRepository */
-			$siteRepository = $this->objectManager->get(\TYPO3\Neos\Domain\Repository\SiteRepository::class);
+        if ($this->context === null) {
+            /** @var \TYPO3\Neos\Domain\Repository\SiteRepository $siteRepository */
+            $siteRepository = $this->objectManager->get(\TYPO3\Neos\Domain\Repository\SiteRepository::class);
 
-			/** @var \TYPO3\TYPO3CR\Domain\Service\ContextFactoryInterface $contextFactory */
-			$contextFactory = $this->objectManager->get(\TYPO3\TYPO3CR\Domain\Service\ContextFactoryInterface::class);
-			$this->context = $contextFactory->create([
-				'currentSite' => $siteRepository->findFirstOnline(),
-				'invisibleContentShown' => true,
-			]);
-		}
+            /** @var \TYPO3\TYPO3CR\Domain\Service\ContextFactoryInterface $contextFactory */
+            $contextFactory = $this->objectManager->get(\TYPO3\TYPO3CR\Domain\Service\ContextFactoryInterface::class);
+            $this->context = $contextFactory->create([
+                'currentSite' => $siteRepository->findFirstOnline(),
+                'invisibleContentShown' => true,
+            ]);
+        }
 
-		return $this->context;
-	}
+        return $this->context;
+    }
 
-	/** @var \TYPO3\TYPO3CR\Domain\Model\NodeInterface */
-	protected $node = null;
-	/** @var string */
-	protected $nodeIdentifier = null;
+    /** @var \TYPO3\TYPO3CR\Domain\Model\NodeInterface */
+    protected $node = null;
+    /** @var string */
+    protected $nodeIdentifier = null;
 
-	/**
-	 * @return \TYPO3\TYPO3CR\Domain\Model\NodeInterface
-	 */
-	protected function getNode() {
-		if ($this->node === null && $this->nodeIdentifier !== null) {
-			$this->node = $this->getContext()->getNodeByIdentifier($this->nodeIdentifier);
-		}
+    /**
+     * @return \TYPO3\TYPO3CR\Domain\Model\NodeInterface
+     */
+    protected function getNode()
+    {
+        if ($this->node === null && $this->nodeIdentifier !== null) {
+            $this->node = $this->getContext()->getNodeByIdentifier($this->nodeIdentifier);
+        }
 
-		return $this->node;
-	}
+        return $this->node;
+    }
 
-	protected function setNode(\TYPO3\TYPO3CR\Domain\Model\NodeInterface $node) {
-		$this->node = $node;
-		$this->nodeIdentifier = $node->getIdentifier();
-	}
+    protected function setNode(\TYPO3\TYPO3CR\Domain\Model\NodeInterface $node)
+    {
+        $this->node = $node;
+        $this->nodeIdentifier = $node->getIdentifier();
+    }
 
-	protected $nodeTypeManager;
+    protected $nodeTypeManager;
 
-	/**
-	 * @return \TYPO3\TYPO3CR\Domain\Service\NodeTypeManager
-	 */
-	protected function getNodeTypeManager() {
-		if ($this->nodeTypeManager === null) {
-			$this->nodeTypeManager = $this->objectManager->get(\TYPO3\TYPO3CR\Domain\Service\NodeTypeManager::class);
-		}
+    /**
+     * @return \TYPO3\TYPO3CR\Domain\Service\NodeTypeManager
+     */
+    protected function getNodeTypeManager()
+    {
+        if ($this->nodeTypeManager === null) {
+            $this->nodeTypeManager = $this->objectManager->get(\TYPO3\TYPO3CR\Domain\Service\NodeTypeManager::class);
+        }
 
-		return $this->nodeTypeManager;
-	}
+        return $this->nodeTypeManager;
+    }
 
-	/**
-	 * Gets an existing node or page on path
-	 *
-	 * @param $path string absolute path, relative to /sites/my-site-name, e.g. /home
-	 *
-	 * @return \TYPO3\TYPO3CR\Domain\Model\NodeInterface
-	 */
-	protected function getNodeForPath($path) {
-		$path = strpos('/sites', $path) === 0 ? $path : $this->getContext()->getCurrentSiteNode()->getPath() . $path;
-		return $this->getContext()->getNode($path);
-	}
+    /**
+     * Gets an existing node or page on path
+     *
+     * @param $path string absolute path, relative to /sites/my-site-name, e.g. /home
+     *
+     * @return \TYPO3\TYPO3CR\Domain\Model\NodeInterface
+     */
+    protected function getNodeForPath($path)
+    {
+        $path = strpos('/sites', $path) === 0 ? $path : $this->getContext()->getCurrentSiteNode()->getPath() . $path;
 
-	protected function persist() {
-		$this->getSubcontext('flow')->persistAll();
-		$this->resetNodeInstances();
-		$this->node = null;
-		$this->context = null;
-	}
+        return $this->getContext()->getNode($path);
+    }
 
-	/**
-	 * Map a String Value to the corresponding Neos Object
-	 *
-	 * @param $propertyName string
-	 * @param $stringInput string
-	 *
-	 * @return mixed
-	 */
-	protected function propertyMapper($propertyName, $stringInput) {
+    protected function persist()
+    {
+        $this->getSubcontext('flow')->persistAll();
+        $this->resetNodeInstances();
+        $this->node = null;
+        $this->context = null;
+    }
 
-		if ($stringInput === 'NULL') {
-			return null;
-		}
+    /**
+     * Map a String Value to the corresponding Neos Object
+     *
+     * @param $propertyName string
+     * @param $stringInput string
+     *
+     * @return mixed
+     */
+    protected function propertyMapper($propertyName, $stringInput)
+    {
 
-		switch ($this->getNode()->getNodeType()->getConfiguration('properties.' . $propertyName . '.type')) {
+        if ($stringInput === 'NULL') {
+            return null;
+        }
 
-		case 'references':
-			$value = array_map(function ($path) { return $this->getNodeForPath($path); }, preg_split('/,\w*/', $stringInput));
-			break;
+        switch ($this->getNode()->getNodeType()->getConfiguration('properties.' . $propertyName . '.type')) {
 
-		case 'reference':
-			$value = $this->getNodeForPath($stringInput);
-			break;
+            case 'references':
+                $value = array_map(function ($path) { return $this->getNodeForPath($path); },
+                    preg_split('/,\w*/', $stringInput));
+                break;
 
-		case 'DateTime':
-			$value = new \DateTime($stringInput);
-			break;
+            case 'reference':
+                $value = $this->getNodeForPath($stringInput);
+                break;
 
-		case 'integer':
-			$value = intval($stringInput);
-			break;
+            case 'DateTime':
+                $value = new \DateTime($stringInput);
+                break;
 
-		case 'boolean':
-			$value = boolval($stringInput);
-			break;
+            case 'integer':
+                $value = intval($stringInput);
+                break;
 
-		case \TYPO3\Media\Domain\Model\ImageInterface::class:
-			if ($stringInput) {
-				/** @var SampleImageService $imageService */
-				$imageService = $this->objectManager->get(SampleImageService::class);
-				$value = $imageService->getSampleImage($stringInput);
-			} else {
-				$value = null;
-			}
+            case 'boolean':
+                $value = boolval($stringInput);
+                break;
 
-			break;
+            case \TYPO3\Media\Domain\Model\ImageInterface::class:
+                if ($stringInput) {
+                    /** @var SampleImageService $imageService */
+                    $imageService = $this->objectManager->get(SampleImageService::class);
+                    $value = $imageService->getSampleImage($stringInput);
+                } else {
+                    $value = null;
+                }
 
-		default:
-			$value = $stringInput;
-			break;
-		}
+                break;
 
-		return $value;
-	}
+            default:
+                $value = $stringInput;
+                break;
+        }
 
-	/**
-	 * @When /^I set the page properties:$/
-	 */
-	public function iSetThePageProperties(TableNode $table) {
-		Assert::assertNotNull($this->getNode());
-		foreach ($table->getRows() as $row) {
-			list($propertyName, $propertyValue) = $row;
-			$value = $this->propertyMapper($propertyName, $propertyValue);
-			$this->getNode()->setProperty($propertyName, $value);
-		}
+        return $value;
+    }
 
-		$this->persist();
-		$this->clearContentCache();
-	}
+    /**
+     * @When /^I set the page properties:$/
+     */
+    public function iSetThePageProperties(TableNode $table)
+    {
+        Assert::assertNotNull($this->getNode());
+        foreach ($table->getRows() as $row) {
+            list($propertyName, $propertyValue) = $row;
+            $value = $this->propertyMapper($propertyName, $propertyValue);
+            $this->getNode()->setProperty($propertyName, $value);
+        }
 
-	/**
-	 * @Given /^I create a new Page "([^"]*)" of type "([^"]*)" on path "([^"]*)"$/
-	 */
-	public function iCreateANewPageOfTypeOnPath($title, $type, $path) {
-		$type = $this->getNodeTypeManager()->getNodeType($type);
-		$folder = $this->getNodeForPath($path);
-		$this->setNode($folder->createNode($title, $type));
-		$this->persist();
-	}
+        $this->persist();
+        $this->clearContentCache();
+    }
 
-	/**
-	 * @Given /^I should have a Page of type "([^"]*)" on path "([^"]*)"$/
-	 */
-	public function iShouldHaveAPageOfTypeOnPath($nodeType, $path) {
-		$node = $this->getNodeForPath($path);
-		Assert::assertNotNull($node);
-		Assert::assertTrue($node->getNodeType()->isOfType($nodeType));
-		$this->setNode($node);
-	}
+    /**
+     * @Given /^I create a new Page "([^"]*)" of type "([^"]*)" on path "([^"]*)"$/
+     */
+    public function iCreateANewPageOfTypeOnPath($title, $type, $path)
+    {
+        $type = $this->getNodeTypeManager()->getNodeType($type);
+        $folder = $this->getNodeForPath($path);
+        $this->setNode($folder->createNode($title, $type));
+        $this->persist();
+    }
 
-	/**
-	 * @Then /^I should get the page properties:$/
-	 */
-	public function iShouldGetThePageProperties(TableNode $table) {
-		Assert::assertNotNull($this->getNode());
-		foreach ($table->getRows() as $row) {
-			list($propertyName, $propertyValue) = $row;
-			Assert::assertTrue($this->getNode()->hasProperty($propertyName));
-			$expectedValue = $this->propertyMapper($propertyName, $propertyValue);
-			Assert::assertEquals($this->getNode()->getProperty($propertyName), $expectedValue);
-		}
-	}
+    /**
+     * @Given /^I should have a Page of type "([^"]*)" on path "([^"]*)"$/
+     */
+    public function iShouldHaveAPageOfTypeOnPath($nodeType, $path)
+    {
+        $node = $this->getNodeForPath($path);
+        Assert::assertNotNull($node);
+        Assert::assertTrue($node->getNodeType()->isOfType($nodeType));
+        $this->setNode($node);
+    }
 
-	/**
-	 * @When /^I (un|)hide the Page$/
-	 */
-	public function iHideThePage($unhide) {
-		Assert::assertNotNull($this->getNode());
-		$this->getNode()->setHidden(!$unhide);
-		$this->persist();
-	}
+    /**
+     * @Then /^I should get the page properties:$/
+     */
+    public function iShouldGetThePageProperties(TableNode $table)
+    {
+        Assert::assertNotNull($this->getNode());
+        foreach ($table->getRows() as $row) {
+            list($propertyName, $propertyValue) = $row;
+            Assert::assertTrue($this->getNode()->hasProperty($propertyName));
+            $expectedValue = $this->propertyMapper($propertyName, $propertyValue);
+            Assert::assertEquals($this->getNode()->getProperty($propertyName), $expectedValue);
+        }
+    }
 
-	/**
-	 * @When /^I move the Page into "([^"]*)"$/
-	 */
-	public function iMoveThePageInto($path) {
-		Assert::assertNotNull($this->getNode());
-		$moveInto = $this->getNodeForPath($path);
-		Assert::assertNotNull($moveInto, 'target path cannot be resolved');
-		$this->getNode()->moveInto($moveInto);
-		$this->persist();
-	}
+    /**
+     * @When /^I (un|)hide the Page$/
+     */
+    public function iHideThePage($unhide)
+    {
+        Assert::assertNotNull($this->getNode());
+        $this->getNode()->setHidden(!$unhide);
+        $this->persist();
+    }
 
-	/**
-	 * @Given /^I wait (\d+) second(?:|s)$/
-	 */
-	public function iWaitSecond($seconds) {
-		sleep($seconds);
-	}
+    /**
+     * @When /^I move the Page into "([^"]*)"$/
+     */
+    public function iMoveThePageInto($path)
+    {
+        Assert::assertNotNull($this->getNode());
+        $moveInto = $this->getNodeForPath($path);
+        Assert::assertNotNull($moveInto, 'target path cannot be resolved');
+        $this->getNode()->moveInto($moveInto);
+        $this->persist();
+    }
+
+    /**
+     * @Given /^I wait (\d+) second(?:|s)$/
+     */
+    public function iWaitSecond($seconds)
+    {
+        sleep($seconds);
+    }
 }


### PR DESCRIPTION
https://circleci.com/gh/cron-eu/daz-neos-base/875

As we have advanced security settings in **policy.yaml** in DAVDAZ-811, we need to initialize the security properly with **$this->setupSecurity();** in the feature context base. This is also needed for NEOS 2.3!
