### PR TITLE
DAVDAZ-1411 Extend comment function

### DIFF
--- a/Tests/Behat/NeosTrait.php
+++ b/Tests/Behat/NeosTrait.php
@@ -343,6 +343,17 @@ trait NeosTrait
     }
 
     /**
+     * @Given /^I set the node "([^"]*)" property to the current date and sub a date interval "([^"]*)"$/
+     */
+    public function iSetTheNodePropertyToTheCurrentDateAndSubADateInterval($propertyName, $intervalString)
+    {
+        $date = new \DateTime();
+        $date->sub(new \DateInterval($intervalString));
+        $this->iSetTheNodePropertyTo($propertyName, $date);
+    }
+
+
+    /**
      * @Given /^I create an empty site with package key "([^"]*)" named "([^"]*)" with a root node of type "([^"]*)"$/
      */
     public function iCreateAnEmptySiteNamedWithARootNodeOfType($packageKey, $siteName, $rootNodeTypeName)


### PR DESCRIPTION
This PR adds a function to subtract a data interval from a current date, with this we can test the situation if a comment older then 4 weeks.

https://github.com/cron-eu/daz-neos-base/pull/1059